### PR TITLE
Fix inconsistencies in magnetic inversion types. 

### DIFF
--- a/geoapps/em1d_inversion.py
+++ b/geoapps/em1d_inversion.py
@@ -196,7 +196,7 @@ def inversion(input_file):
     hz_min, expansion, n_cells = input_param["mesh 1D"]
     ignore_values = input_param["ignore_values"]
     max_iteration = input_param["max_iterations"]
-    resolution = np.float(input_param["resolution"])
+    resolution = float(input_param["resolution"])
 
     if "window" in input_param.keys():
         window = input_param["window"]
@@ -325,7 +325,7 @@ def inversion(input_file):
 
             for line in values:
 
-                line_ind = np.where(entity.get_data(key)[0].values == np.float(line))[0]
+                line_ind = np.where(entity.get_data(key)[0].values == float(line))[0]
 
                 if len(line_ind) < 2:
                     continue
@@ -476,9 +476,9 @@ def inversion(input_file):
 
         for line in values:
 
-            line_ind = np.where(
-                entity.get_data(key)[0].values[win_ind] == np.float(line)
-            )[0]
+            line_ind = np.where(entity.get_data(key)[0].values[win_ind] == float(line))[
+                0
+            ]
 
             n_sounding = len(line_ind)
             if n_sounding < 2:
@@ -536,9 +536,9 @@ def inversion(input_file):
             model_ordering.append(temp[:, order].T.ravel() + model_count)
             model_vertices.append(np.c_[np.ravel(X), np.ravel(Y), np.ravel(Z)])
             model_cells.append(tri2D.simplices + model_count)
-            model_line_ids.append(np.ones_like(np.ravel(X)) * np.float(line))
+            model_line_ids.append(np.ones_like(np.ravel(X)) * float(line))
 
-            line_ids.append(np.ones_like(order) * np.float(line))
+            line_ids.append(np.ones_like(order) * float(line))
             data_ordering.append(order + pred_count)
 
             pred_vertices.append(xyz[order, :])
@@ -675,11 +675,11 @@ def inversion(input_file):
 
     if len(ignore_values) > 0:
         if "<" in ignore_values:
-            uncert[dobs <= np.float(ignore_values.split("<")[1])] = np.inf
+            uncert[dobs <= float(ignore_values.split("<")[1])] = np.inf
         elif ">" in ignore_values:
-            uncert[dobs >= np.float(ignore_values.split(">")[1])] = np.inf
+            uncert[dobs >= float(ignore_values.split(">")[1])] = np.inf
         else:
-            uncert[dobs == np.float(ignore_values)] = np.inf
+            uncert[dobs == float(ignore_values)] = np.inf
 
     uncert[(dobs > 1e-38) * (dobs < 2e-38)] = np.inf
 
@@ -981,16 +981,16 @@ def inversion(input_file):
         #     if "<" in ignore_values:
         #         uncert[
         #             data_mapping * dobs / normalization
-        #             <= np.float(ignore_values.split("<")[1])
+        #             <= float(ignore_values.split("<")[1])
         #         ] = np.inf
         #     elif ">" in ignore_values:
         #         uncert[
         #             data_mapping * dobs / normalization
-        #             >= np.float(ignore_values.split(">")[1])
+        #             >= float(ignore_values.split(">")[1])
         #         ] = np.inf
         #     else:
         #         uncert[
-        #             data_mapping * dobs / normalization == np.float(ignore_values)
+        #             data_mapping * dobs / normalization == float(ignore_values)
         #         ] = np.inf
 
     mesh_reg = get_2d_mesh(n_sounding, hz)

--- a/geoapps/pf_inversion.py
+++ b/geoapps/pf_inversion.py
@@ -222,13 +222,13 @@ def inversion(input_file):
 
     assert "inversion_type" in list(
         input_dict.keys()
-    ), "Require 'inversion_type' to be set: 'gravity', 'mag', 'mvi', or 'magnetics'"
+    ), "Require 'inversion_type' to be set: 'gravity', 'magnetics', 'mvi', or 'mvic'"
     assert input_dict["inversion_type"] in [
         "gravity",
-        "mag",
-        "mvi",
         "magnetics",
-    ], "'inversion_type' must be one of: 'gravity', 'mag', 'mvi', or 'magnetics'"
+        "mvi",
+        "mvic",
+    ], "'inversion_type' must be one of: 'gravity', 'magnetics', 'mvi', or 'mvic'"
 
     if "inversion_style" in list(input_dict.keys()):
         inversion_style = input_dict["inversion_style"]
@@ -754,7 +754,7 @@ def inversion(input_file):
     else:
         output_tile_files = False
 
-    if input_dict["inversion_type"] in ["mvi", "magnetics", "mvic"]:
+    if "mvi" in input_dict["inversion_type"]:
         vector_property = True
         n_blocks = 3
         if len(model_norms) == 4:
@@ -804,7 +804,7 @@ def inversion(input_file):
             local_survey.std = survey.std[data_ind]
             local_survey.ind = np.where(ind_t)[0]
 
-        elif input_dict["inversion_type"] in ["mag", "mvi", "magnetics"]:
+        elif input_dict["inversion_type"] in ["magnetics", "mvi", "mvic"]:
             rxLoc_t = PF.BaseMag.RxObs(rxLoc[ind_t, :])
             srcField = PF.BaseMag.SrcField([rxLoc_t], param=survey.srcField.param)
             local_survey = PF.BaseMag.LinearSurvey(
@@ -1170,7 +1170,7 @@ def inversion(input_file):
         activeCells_t = np.ones(local_mesh.nC, dtype="bool")
 
         # Create reduced identity map
-        if input_dict["inversion_type"] in ["mvi", "magnetics"]:
+        if "mvi" in input_dict["inversion_type"]:
             nBlock = 3
         else:
             nBlock = 1
@@ -1196,7 +1196,7 @@ def inversion(input_file):
                 chunk_by_rows=chunk_by_rows,
             )
 
-        elif input_dict["inversion_type"] == "mag":
+        elif input_dict["inversion_type"] == "magnetics":
             prob = PF.Magnetics.MagneticIntegral(
                 local_mesh,
                 chiMap=tile_map * model_map,
@@ -1211,7 +1211,7 @@ def inversion(input_file):
                 chunk_by_rows=chunk_by_rows,
             )
 
-        elif input_dict["inversion_type"] in ["mvi", "magnetics"]:
+        elif "mvi" in input_dict["inversion_type"]:
             prob = PF.Magnetics.MagneticIntegral(
                 local_mesh,
                 chiMap=tile_map * model_map,

--- a/geoapps/pf_inversion.py
+++ b/geoapps/pf_inversion.py
@@ -320,15 +320,11 @@ def inversion(input_file):
             ignore_values = input_dict["ignore_values"]
             if len(ignore_values) > 0:
                 if "<" in ignore_values:
-                    uncertainties[
-                        data <= np.float(ignore_values.split("<")[1])
-                    ] = np.inf
+                    uncertainties[data <= float(ignore_values.split("<")[1])] = np.inf
                 elif ">" in ignore_values:
-                    uncertainties[
-                        data >= np.float(ignore_values.split(">")[1])
-                    ] = np.inf
+                    uncertainties[data >= float(ignore_values.split(">")[1])] = np.inf
                 else:
-                    uncertainties[data == np.float(ignore_values)] = np.inf
+                    uncertainties[data == float(ignore_values)] = np.inf
 
         if isinstance(entity, Grid2D):
             vertices = entity.centroids
@@ -1417,10 +1413,9 @@ def inversion(input_file):
     # Add a list of directives to the inversion
     directiveList = []
 
-    if vector_property:
+    if vector_property and input_dict["inversion_type"] == "mvi":
         directiveList.append(
             Directives.VectorInversion(
-                inversion_type=input_dict["inversion_type"],
                 chifact_target=target_chi * 2,
             )
         )


### PR DESCRIPTION
A reference to `mvic' was present after the assert statement would have failed. Different references to mvi or magnetics or mvic in different places: sometimes three types being set as vector mag (mvi, magnetics, mvic), and sometime two types (mvi, magnetics).

I streamlined all the calls with: magnetics( = magsus), mvi (spherical), and mvic (cartesian), and eliminated mag. I think you were using magnetics to mean MVIC, but I thought it made sense to clarify which was a vector and which wasn't.