### PR TITLE
Change reference to python 3.7

### DIFF
--- a/docs/content/installation.rst
+++ b/docs/content/installation.rst
@@ -8,7 +8,7 @@ Whether you are developer or an end-user, this page will help you get started wi
 Installation
 ------------
 
-- Make sure that you have `Anaconda 3.6 <https://www.anaconda.com/download/>`_ or higher installed.
+- Make sure that you have `Anaconda 3.7 <https://www.anaconda.com/download/>`_ or higher installed.
 
 	.. figure:: ../images/Anaconda_Install.png
 	    :align: center


### PR DESCRIPTION
**GEOPY-98 - Python 3.6.X not supported with pip install** 
 Needed for docs.