### PR TITLE
GEOPY-177: add platform to pytest job

### DIFF
--- a/.github/workflows/pytest-unix-os.yaml
+++ b/.github/workflows/pytest-unix-os.yaml
@@ -17,7 +17,7 @@ on:
 
 jobs:
   pytest:
-    name: pytest
+    name: pytest (Ubuntu)
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/pytest-windows.yaml
+++ b/.github/workflows/pytest-windows.yaml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   pytest:
-    name: pytest
+    name: pytest (Windows)
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
**GEOPY-177 - python version not used in github actions** 
 so that they appear as two different jobs in PR required conditions