### PR TITLE
GEOPY-258: fixup github workfow file for Unix

### DIFF
--- a/.github/workflows/pytest-unix-os.yaml
+++ b/.github/workflows/pytest-unix-os.yaml
@@ -2,6 +2,7 @@ name: pytest on Unix OS
 
 on:
   pull_request:
+    branches:
       - main
       - hotfix/**
       - release/**

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -58,6 +58,7 @@ repos:
     -   id: trailing-whitespace
         exclude: \.mdj$
     -   id: check-toml
+    -   id: check-yaml
 #    -   id: check-added-large-files # crashing on some configuration. To be investigated
     -   id: check-case-conflict
     -   id: check-merge-conflict

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -68,6 +68,10 @@ repos:
         exclude: \.mdj$
     -   id: mixed-line-ending
     -   id: name-tests-test
+-   repo: https://github.com/sirosen/check-jsonschema
+    rev: 0.3.1
+    hooks:
+    -   id: check-github-workflows
 -   repo: local
     hooks:
     -   id: rstcheck

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -68,10 +68,6 @@ repos:
         exclude: \.mdj$
     -   id: mixed-line-ending
     -   id: name-tests-test
--   repo: https://github.com/sirosen/check-jsonschema
-    rev: 0.3.1
-    hooks:
-    -   id: check-github-workflows
 -   repo: local
     hooks:
     -   id: rstcheck


### PR DESCRIPTION
**GEOPY-258 - change required test platforms per branch** 
 fixup for https://github.com/MiraGeoscience/geoapps/pull/108

relates to https://github.com/MiraGeoscience/geoh5py/pull/104