### PR TITLE
Geopy 269

### DIFF
--- a/geoapps/drivers/base_inversion.py
+++ b/geoapps/drivers/base_inversion.py
@@ -93,7 +93,6 @@ class InversionDriver:
         self.inversion_data = InversionData(
             self.workspace,
             self.params,
-            self.window,
         )
 
         self.inversion_topography = InversionTopography(

--- a/geoapps/drivers/base_inversion.py
+++ b/geoapps/drivers/base_inversion.py
@@ -135,7 +135,7 @@ class InversionDriver:
         print("Number of tiles:" + str(self.nTiles))
 
         # Build tiled misfits and combine to form global misfit
-        local_misfits = self.calculate_tile_misfits(self.tiles)
+        local_misfits = self.get_tile_misfits(self.tiles)
         global_misfit = objective_function.ComboObjectiveFunction(local_misfits)
 
         # Trigger sensitivity calcs
@@ -143,7 +143,7 @@ class InversionDriver:
             local.simulation.Jmatrix
 
         # Create regularization
-        wr = self.calculate_weighting_matrix(global_misfit)
+        wr = self.get_weighting_matrix(global_misfit)
         reg = self.get_regularization(wr)
 
         # Specify optimization algorithm and set parameters
@@ -276,7 +276,7 @@ class InversionDriver:
         self.save_residuals(predicted_data_object, dpred)
         self.finish_inversion_message(dpred)
 
-    def calculate_weighting_matrix(self, global_misfit):
+    def get_weighting_matrix(self, global_misfit):
         """Calculate diagonal weighting matrix for regularization.
         :param global_misfit: global misfit function.
         :return: wr: Diagonal weighting matrix.
@@ -447,7 +447,7 @@ class InversionDriver:
 
         return tiles
 
-    def calculate_tile_misfits(self, tiles):
+    def get_tile_misfits(self, tiles):
 
         local_misfits, self.sorting = [], []
         for tile_id, local_index in enumerate(tiles):

--- a/geoapps/drivers/base_inversion.py
+++ b/geoapps/drivers/base_inversion.py
@@ -90,10 +90,7 @@ class InversionDriver:
 
         self.inversion_window = InversionWindow(self.workspace, self.params)
 
-        self.inversion_data = InversionData(
-            self.workspace,
-            self.params,
-        )
+        self.inversion_data = InversionData(self.workspace, self.params, self.window)
 
         self.inversion_topography = InversionTopography(
             self.workspace, self.params, self.window

--- a/geoapps/drivers/components/data.py
+++ b/geoapps/drivers/components/data.py
@@ -110,7 +110,8 @@ class InversionData(InversionLocations):
         self.components, self.data, self.uncertainties = self.get_data()
 
         self.locations = super().get_locations(self.params.data_object)
-        self.locations = super().z_from_topo(self.locations)
+        if self.params.z_from_topo:
+            self.locations = super().set_z_from_topo(self.locations)
         self.mask = np.ones(len(self.locations), dtype=bool)
 
         if self.window is not None:

--- a/geoapps/drivers/components/data.py
+++ b/geoapps/drivers/components/data.py
@@ -26,6 +26,8 @@ class InversionData(InversionLocations):
     Methods
     -------
 
+    survey: Generates SimPEG survey object.
+    simulation: Generates SimPEG simulation object.
 
     """
 
@@ -204,7 +206,7 @@ class InversionData(InversionLocations):
         return locs + offset if offset is not None else 0
 
     def drape(self, radar_offset: np.ndarray, locs: np.ndarray) -> np.ndarray:
-        """ Drape data locations using radar channel. """
+        """ Drape data locations using radar channel offsets. """
 
         radar_offset_pad = np.zeros((len(radar_offset), 3))
         radar_offset_pad[:, 2] = radar_offset

--- a/geoapps/drivers/components/data.py
+++ b/geoapps/drivers/components/data.py
@@ -140,6 +140,7 @@ class InversionData(InversionLocations):
             self.locations = self.displace(self.locations, self.offset)
         if self.radar is not None:
             radar_offset = self.workspace.get_entity(self.radar)[0].values
+            radar_offset = super().filter(radar_offset)
             self.locations = self.drape(self.locations, radar_offset)
 
         if self.is_rotated:

--- a/geoapps/drivers/components/locations.py
+++ b/geoapps/drivers/components/locations.py
@@ -149,7 +149,7 @@ class InversionLocations:
     def z_from_topo(self, locs: np.ndarray):
         """ interpolate locations z data from topography. """
 
-        topo = self.get_locs(self.params.topography_object)
+        topo = self.get_locations(self.params.topography_object)
 
         xyz = locs.copy()
         topo_interpolator = LinearNDInterpolator(topo[:, :2], topo[:, 2])

--- a/geoapps/drivers/components/locations.py
+++ b/geoapps/drivers/components/locations.py
@@ -147,7 +147,7 @@ class InversionLocations:
         xy = rotate_xy(locs[:, :2], self.origin, self.angle)
         return np.c_[xy, locs[:, 2]]
 
-    def z_from_topo(self, locs: np.ndarray):
+    def set_z_from_topo(self, locs: np.ndarray):
         """ interpolate locations z data from topography. """
 
         topo = self.get_locations(self.params.topography_object)

--- a/geoapps/drivers/components/locations.py
+++ b/geoapps/drivers/components/locations.py
@@ -111,12 +111,6 @@ class InversionLocations:
             msg += " Object type should be Grid2D or point-like."
             raise (ValueError(msg))
 
-        if data_object.uid == self.params.topography_object:
-            if self.params.topography is not None:
-                elev = self.workspace.get_entity(self.params.topography)[0].values
-                if not np.all(locs[:, 2] == elev):
-                    locs[:, 2] = elev
-
         return locs
 
     def filter(self, a: Union[Dict[str, np.ndarray], np.ndarray]):

--- a/geoapps/drivers/components/topography.py
+++ b/geoapps/drivers/components/topography.py
@@ -56,10 +56,7 @@ class InversionTopography(InversionLocations):
 
     def _initialize(self):
 
-        self.locations = super().get_locations(self.params.topography_object)
-        elev = self.workspace.get_entity(self.params.topography)[0].values
-        if not np.all(self.locations[:, 2] == elev):
-            self.locations[:, 2] = elev
+        self.locations = self.get_locations(self.params.topography_object)
 
         self.mask = np.ones(len(self.locations), dtype=bool)
 
@@ -89,3 +86,23 @@ class InversionTopography(InversionLocations):
         active_cells = active_from_xyz(mesh, self.locations, grid_reference="N")
 
         return active_cells
+
+    def get_locations(self, uid: UUID) -> np.ndarray:
+        """
+        Returns locations of data object centroids or vertices.
+
+        :param uid: UUID of geoh5py object containing centroid or
+            vertex location data
+
+        :return: Array shape(*, 3) of x, y, z location data
+
+        """
+
+        locs = super().get_locations(uid)
+
+        if self.params.topography is not None:
+            elev = self.workspace.get_entity(self.params.topography)[0].values
+            if not np.all(locs[:, 2] == elev):
+                locs[:, 2] = elev
+
+        return locs

--- a/geoapps/io/Gravity/constants.py
+++ b/geoapps/io/Gravity/constants.py
@@ -4,11 +4,6 @@
 #
 #  geoapps is distributed under the terms and conditions of the MIT License
 #  (see LICENSE file at the root of this source code package).
-#
-#  This file is part of geoapps.
-#
-#  geoapps is distributed under the terms and conditions of the MIT License
-#  (see LICENSE file at the root of this source code package).
 
 from uuid import UUID
 
@@ -134,6 +129,13 @@ default_ui_json = {
         "parent": "data_object",
         "property": None,
         "value": 1,
+    },
+    "z_from_topo": {
+        "default": True,
+        "main": True,
+        "group": "Receivers Options",
+        "label": "Take z from topography?",
+        "value": True,
     },
     "receivers_radar_drape": {
         "association": "Cell",
@@ -730,11 +732,11 @@ default_ui_json = {
         "value": None,
     },
     "out_group": {
-        "default": "MVIInversion",
+        "default": "GravInversion",
         "visible": True,
         "enabled": True,
         "label": "results group name",
-        "value": "MVIInversion",
+        "value": "GravInversion",
     },
     "no_data_value": {
         "default": 0,
@@ -809,6 +811,7 @@ validations = {
     "tile_spatial": {
         "types": [str, int, float],
     },
+    "z_from_topo": {"types": [bool]},
     "receivers_radar_drape": {"types": [str], "reqs": [("data_object")]},
     "receivers_offset_x": {
         "types": [int, float],

--- a/geoapps/io/Gravity/params.py
+++ b/geoapps/io/Gravity/params.py
@@ -34,6 +34,7 @@ class GravityParams(Params):
         self.starting_model_object = None
         self.starting_model = None
         self.tile_spatial = None
+        self.z_from_topo = None
         self.receivers_radar_drape = None
         self.receivers_offset_x = None
         self.receivers_offset_y = None
@@ -296,6 +297,21 @@ class GravityParams(Params):
             p, val, self.validations[p], self.workspace, self.associations
         )
         self._tile_spatial = UUID(val) if isinstance(val, str) else val
+
+    @property
+    def z_from_topo(self):
+        return self._z_from_topo
+
+    @z_from_topo.setter
+    def z_from_topo(self, val):
+        if val is None:
+            self._z_from_topo = val
+            return
+        p = "z_from_topo"
+        self.validator.validate(
+            p, val, self.validations[p], self.workspace, self.associations
+        )
+        self._z_from_topo = val
 
     @property
     def receivers_radar_drape(self):

--- a/geoapps/io/MVI/constants.py
+++ b/geoapps/io/MVI/constants.py
@@ -4,11 +4,6 @@
 #
 #  geoapps is distributed under the terms and conditions of the MIT License
 #  (see LICENSE file at the root of this source code package).
-#
-#  This file is part of geoapps.
-#
-#  geoapps is distributed under the terms and conditions of the MIT License
-#  (see LICENSE file at the root of this source code package).
 
 from uuid import UUID
 
@@ -219,6 +214,13 @@ default_ui_json = {
         "parent": "data_object",
         "property": None,
         "value": 1,
+    },
+    "z_from_topo": {
+        "default": True,
+        "main": True,
+        "group": "Receivers Options",
+        "label": "Take z from topography?",
+        "value": True,
     },
     "receivers_radar_drape": {
         "association": "Cell",
@@ -978,6 +980,7 @@ validations = {
     "tile_spatial": {
         "types": [str, int, float],
     },
+    "z_from_topo": {"types": [bool]},
     "receivers_radar_drape": {"types": [str], "reqs": [("data_object")]},
     "receivers_offset_x": {
         "types": [int, float],

--- a/geoapps/io/MVI/params.py
+++ b/geoapps/io/MVI/params.py
@@ -41,6 +41,7 @@ class MVIParams(Params):
         self.starting_inclination = None
         self.starting_declination = None
         self.tile_spatial = None
+        self.z_from_topo = None
         self.receivers_radar_drape = None
         self.receivers_offset_x = None
         self.receivers_offset_y = None
@@ -422,6 +423,21 @@ class MVIParams(Params):
             p, val, self.validations[p], self.workspace, self.associations
         )
         self._tile_spatial = UUID(val) if isinstance(val, str) else val
+
+    @property
+    def z_from_topo(self):
+        return self._z_from_topo
+
+    @z_from_topo.setter
+    def z_from_topo(self, val):
+        if val is None:
+            self._z_from_topo = val
+            return
+        p = "z_from_topo"
+        self.validator.validate(
+            p, val, self.validations[p], self.workspace, self.associations
+        )
+        self._z_from_topo = val
 
     @property
     def receivers_radar_drape(self):

--- a/tests/data_test.py
+++ b/tests/data_test.py
@@ -147,26 +147,11 @@ def test_displace(tmp_path):
 def test_drape(tmp_path):
     ws, params = setup_params(tmp_path)
     window = params.window()
-    topo = InversionTopography(ws, params, window)
     data = InversionData(ws, params, window)
-
-    # create radar object with z channel an set uid to data.radar
     test_locs = np.array([[1.0, 2.0, 1.0], [2.0, 1.0, 1.0], [8.0, 9.0, 1.0]])
     radar_ch = np.array([1.0, 2.0, 3.0])
-    drape_object = Points.create(ws, name="test_drape", vertices=test_locs)
-    test_drape = drape_object.add_data({"z": {"values": radar_ch}})
-    data.radar = test_drape.uid
-
-    # create topography and set data.topo
-    xg, yg = np.meshgrid(np.linspace(0, 10, 11), np.linspace(0, 10, 11))
-    x = xg.ravel()
-    y = yg.ravel()
-    z = np.ones(x.shape)
-    z[(x > 5) & (y > 5)] = 2
-    topo.locs = np.c_[x, y, z]
-
-    expected_locs = np.array([[1.0, 2.0, 2.0], [2.0, 1.0, 3.0], [8.0, 9.0, 5.0]])
-    draped_locs = data.drape(topo.locs, test_locs)
+    expected_locs = np.array([[1.0, 2.0, 2.0], [2.0, 1.0, 3.0], [8.0, 9.0, 4.0]])
+    draped_locs = data.drape(radar_ch, test_locs)
 
     assert np.all(draped_locs == expected_locs)
 

--- a/tests/locations_test.py
+++ b/tests/locations_test.py
@@ -21,12 +21,12 @@ workspace = Workspace("./FlinFlon.geoh5")
 def setup_params(tmp):
     geotest = Geoh5Tester(workspace, tmp, "test.geoh5", default_ui_json, MVIParams)
     geotest.set_param("mesh", "{e334f687-df71-4538-ad28-264e420210b8}")
+    geotest.set_param("topography_object", "{ab3c2083-6ea8-4d31-9230-7aad3ec09525}")
     return geotest.make()
 
 
 def test_mask(tmp_path):
     ws, params = setup_params(tmp_path)
-    mesh = InversionMesh(ws, params)
     window = params.window()
     locations = InversionLocations(ws, params, window)
     test_mask = [0, 1, 1, 0]
@@ -41,7 +41,6 @@ def test_mask(tmp_path):
 
 def test_get_locs(tmp_path):
     ws, params = setup_params(tmp_path)
-    mesh = InversionMesh(ws, params)
     window = params.window()
     locs = np.ones((10, 3), dtype=float)
     points_object = Points.create(ws, name="test-data", vertices=locs)
@@ -67,7 +66,6 @@ def test_get_locs(tmp_path):
 
 def test_filter(tmp_path):
     ws, params = setup_params(tmp_path)
-    mesh = InversionMesh(ws, params)
     window = params.window()
     locations = InversionLocations(ws, params, window)
     test_data = np.array([0, 1, 2, 3, 4, 5])
@@ -83,9 +81,17 @@ def test_filter(tmp_path):
 def test_rotate(tmp_path):
     # Basic test since rotate_xy already tested
     ws, params = setup_params(tmp_path)
-    mesh = InversionMesh(ws, params)
     window = params.window()
     locations = InversionLocations(ws, params, window)
     test_locs = np.array([[1.0, 2.0, 3.0], [3.0, 4.0, 5.0], [6.0, 7.0, 8.0]])
     locs_rot = locations.rotate(test_locs)
     assert locs_rot.shape == test_locs.shape
+
+
+def test_z_from_topo(tmp_path):
+    ws, params = setup_params(tmp_path)
+    window = params.window()
+    locations = InversionLocations(ws, params, window)
+    locations.locs = np.array([[315674, 6070832, 0]])
+    locs = locations.z_from_topo(locations.locs)
+    assert locs[0, 2] == 326

--- a/tests/locations_test.py
+++ b/tests/locations_test.py
@@ -93,5 +93,5 @@ def test_z_from_topo(tmp_path):
     window = params.window()
     locations = InversionLocations(ws, params, window)
     locations.locs = np.array([[315674, 6070832, 0]])
-    locs = locations.z_from_topo(locations.locs)
+    locs = locations.set_z_from_topo(locations.locs)
     assert locs[0, 2] == 326


### PR DESCRIPTION
**GEOPY-269 - drape option in base inversion driver not working** 
 Added a z_from_topo ui element to receivers group.  When True, the receivers z location is built by interpolation into the topography.  This occurs outside the drape method during class initialization and the drape method now just takes a radar offset array and applies the z translation.  Tests updated.  Inversions are now putting the data where it should be.