### PR TITLE
GEOPY-296: remove one usage of GA abbreviation in doc

### DIFF
--- a/geoapps/io/input_file.py
+++ b/geoapps/io/input_file.py
@@ -106,7 +106,7 @@ class InputFile:
             Parameters to insert in ui_dict values.
             Defaults to the :obj:`InputFile.data` is not provided.
         workspace : optional
-            Provide a workspace_geoh5 path to simulate auto-generated field in GA.
+            Provide a workspace_geoh5 path to simulate auto-generated field in Geoscience ANALYST.
         """
 
         out = deepcopy(ui_dict)


### PR DESCRIPTION
**GEOPY-296 - some typos in doc** 
 