### PR TITLE
GEOPY-310: validating geoh5py==0.1.4rc1

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -28,4 +28,4 @@ dependencies:
   - mkl=2020.4
   - pip:
     - git+https://github.com/MiraGeoscience/simpeg.git@feature/tiled-simulations
-    - geoh5py==0.1.4
+    - geoh5py==0.1.4rc1


### PR DESCRIPTION
**GEOPY-310 - Release 0.5.1 patch** 
 