### PR TITLE
Re-enable output of PF Inversion iteration convergence progress

### DIFF
--- a/geoapps/drivers/pf_inversion.py
+++ b/geoapps/drivers/pf_inversion.py
@@ -1547,9 +1547,9 @@ def inversion(input_file):
     #         vector=input_dict["inversion_type"][0:3] == 'mvi'
     #     )
     # )
-    # save_output = Directives.SaveOutputEveryIteration()
-    # save_output.fileName = workDir + "Output"
-    # directiveList.append(save_output)
+    save_output = Directives.SaveOutputEveryIteration()
+    save_output.fileName = workDir + "Output"
+    directiveList.append(save_output)
 
     # Put all the parts together
     inv = Inversion.BaseInversion(invProb, directiveList=directiveList)

--- a/geoapps/simpegPF/Directives.py
+++ b/geoapps/simpegPF/Directives.py
@@ -579,7 +579,7 @@ class SaveOutputEveryIteration(SaveEveryIteration):
         if self.save_txt:
             f = open(self.fileName + ".txt", "a")
             f.write(
-                " {:3d} {:1.4e} {:1.4e} {:1.4e} {:1.4e} {:1.4e} "
+                " {:3.0f} {:1.4e} {:1.4e} {:1.4e} {:1.4e} {:1.4e} "
                 "{:1.4e}  {:1.4e}  {:1.4e}\n".format(
                     self.opt.iter,
                     self.beta[self.opt.iter - 1],

--- a/geoapps/simpegPF/Directives.py
+++ b/geoapps/simpegPF/Directives.py
@@ -583,7 +583,7 @@ class SaveOutputEveryIteration(SaveEveryIteration):
                 "{:1.4e}  {:1.4e}  {:1.4e}\n".format(
                     self.opt.iter,
                     self.beta[self.opt.iter - 1],
-                    self.phi_d[self.opt.iter - 1],
+                    self.phi_d[self.opt.iter - 1][0],
                     self.phi_m[self.opt.iter - 1][0],
                     self.phi_m_small[self.opt.iter - 1],
                     self.phi_m_smooth_x[self.opt.iter - 1],


### PR DESCRIPTION
`SaveOutputEveryIteration` output directive was commented out of PF inversion code, likely to avoid a bug in the output formatting. This fixes the bug and enables the directive again.