### PR TITLE
GEOPY-334: exclude simpegEM1D and simpegPF from test coverage

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,4 +1,4 @@
 [run]
 omit =
-    geoh5py/handlers/*
-    geoh5py/interfaces/*
+    geoapps/simpegEM1D/*
+    geoapps/simpegPF/*


### PR DESCRIPTION
**GEOPY-334 - exclude simpegEM1D and simpegPF from test coverage** 
 