### PR TITLE
GEOPY-338

### DIFF
--- a/geoapps/drivers/components/meshes.py
+++ b/geoapps/drivers/components/meshes.py
@@ -38,12 +38,6 @@ class InversionMesh:
         Permutation vector to restore cell centers or model values to
         origin Octree mesh order.
 
-
-    Methods
-    -------
-    original_cc() :
-        Returns the cell centers of the original Octree mesh type.
-
     """
 
     def __init__(self, workspace: Workspace, params: Params) -> None:
@@ -92,12 +86,6 @@ class InversionMesh:
 
         self.mesh = octree_2_treemesh(self.entity)
         self.octree_permutation = self.mesh._ubc_order
-
-    def original_cc(self) -> np.ndarray:
-        """Returns the cell centers of the original Octree mesh type."""
-        cc = self.mesh.cell_centers
-        cc = rotate_xy(cc, self.rotation["origin"], self.rotation["angle"])
-        return cc[self.octree_permutation]
 
     def collect_mesh_params(self, params: Params) -> OctreeParams:
         """Collect mesh params from inversion params set and return Octree Params object."""

--- a/geoapps/drivers/components/models.py
+++ b/geoapps/drivers/components/models.py
@@ -370,7 +370,7 @@ class InversionModel:
         else:
             xyz_in = parent.vertices
 
-        xyz_out = self.mesh.original_cc()
+        xyz_out = self.mesh.mesh.cell_centers
 
         return weighted_average(xyz_in, xyz_out, [obj])[0]
 

--- a/tests/meshes_test.py
+++ b/tests/meshes_test.py
@@ -40,14 +40,6 @@ def test_initialize(tmp_path):
     assert inversion_mesh.rotation["angle"] == 20
 
 
-def test_original_cc(tmp_path):
-
-    ws, params = setup_params(tmp_path)
-    inversion_mesh = InversionMesh(ws, params)
-    msh = ws.get_entity(inversion_mesh.uid)[0]
-    np.testing.assert_allclose(msh.centroids, inversion_mesh.original_cc())
-
-
 def test_collect_mesh_params(tmp_path):
     ws, params = setup_params(tmp_path)
     locs = ws.get_entity(params.data_object)[0].centroids


### PR DESCRIPTION
**GEOPY-338 - Forward modeling of Vector model broken** 
 Fix erroneously resorted model and update the test to look at a heterogeneous model instead of constant.