### PR TITLE
GEOPY-358: followup: fix running pylint from precommit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,7 +41,7 @@ repos:
     hooks:
     -   id: pylint
         name: pylint
-        entry: conda activate .\\.conda-env && pylint
+        entry: .\\devtools\\conda_env_pylint.bat
         language: system
         require_serial: true  # pylint does its own parallelism
         types: [python]

--- a/devtools/conda_env_pylint.bat
+++ b/devtools/conda_env_pylint.bat
@@ -1,0 +1,11 @@
+@echo off
+setlocal EnableDelayedExpansion
+
+set project_dir=%~dp0..
+call %project_dir%\get_conda_exec.bat
+if !errorlevel! neq 0 (
+  exit /B !errorlevel!
+)
+
+set env_path=%project_dir%\.conda-env
+call !MY_CONDA_EXE! activate %env_path% && pylint %*


### PR DESCRIPTION
**GEOPY-358 - use local editable geoh5 in geoapps dev environment** 
 