### PR TITLE
Geopy 405

### DIFF
--- a/geoapps/processing/data_interpolation.py
+++ b/geoapps/processing/data_interpolation.py
@@ -91,7 +91,7 @@ class DataInterpolation(ObjectDataSelection):
         )
         self._out_object = Dropdown()
         self._padding_distance = Text(
-            description="Pad Distance (W, E, N, S, D, U)",
+            description="Pad Distance (W, E, S, N, D, U)",
         )
         self._skew_angle = FloatText(
             description="Azimuth (d.dd)",


### PR DESCRIPTION
**GEOPY-405 - Data transfer applies padding to south extent when north is provided** 
 Fix the padding behaviour vs labelling of padding options.  Switched north and south labels