### PR TITLE
GEOPY-395: Remove finish_inversion_method from base driver.

### DIFF
--- a/geoapps/drivers/base_inversion.py
+++ b/geoapps/drivers/base_inversion.py
@@ -210,8 +210,6 @@ class InversionDriver:
         # Run the inversion
         self.start_inversion_message()
         mrec = self.inversion.run(self.starting_model)
-        dpred = self.collect_predicted_data(self.global_misfit, mrec)
-        self.finish_inversion_message(dpred)
 
     def start_inversion_message(self):
 
@@ -232,28 +230,6 @@ class InversionDriver:
             "IRLS Start Misfit: {:.2e} ({} data with chifact = {}) / 2".format(
                 0.5 * chi_start * len(self.survey.std), len(self.survey.std), chi_start
             )
-        )
-
-    def collect_predicted_data(self, global_misfit, mrec):
-
-        dpred = np.hstack(self.inverse_problem.dpred)
-        if getattr(self.survey, "component", None) is not None:
-            dpred = dpred.reshape(-1, len(self.survey.components))
-        sorting = np.argsort(np.hstack(self.sorting))
-        return dpred[sorting].ravel()
-
-    def finish_inversion_message(self, dpred):
-        print(
-            "Target Misfit: %.3e (%.0f data with chifact = %g)"
-            % (
-                0.5 * self.params.chi_factor * len(self.survey.std),
-                len(self.survey.std),
-                self.params.chi_factor,
-            )
-        )
-        print(
-            "Final Misfit:  %.3e"
-            % (0.5 * np.sum(((self.survey.dobs - dpred) / self.survey.std) ** 2.0))
         )
 
     def get_regularization(self):


### PR DESCRIPTION
**GEOPY-395 - save_misfit is not working for multi-component inversions**
Previously merged into dev, but is flagged for 0.6.1 release.