### PR TITLE
move write_default_uijson out of import in init to remove runtimewarning

### DIFF
--- a/geoapps/io/__init__.py
+++ b/geoapps/io/__init__.py
@@ -8,4 +8,3 @@
 from .input_file import InputFile
 from .params import Params
 from .validators import InputFreeformValidator, InputValidator
-from .write_default_uijson import write_default_uijson

--- a/tests/write_default_uijson_test.py
+++ b/tests/write_default_uijson_test.py
@@ -7,7 +7,7 @@
 
 import os
 
-from geoapps.io import write_default_uijson
+from geoapps.io.write_default_uijson import write_default_uijson
 
 
 def test_write_default_uijson(tmp_path):


### PR DESCRIPTION
hotfix to get rid of a warning encountered during demo practise