### PR TITLE
GEOPY-390

### DIFF
--- a/geoapps/io/write_default_uijson.py
+++ b/geoapps/io/write_default_uijson.py
@@ -86,7 +86,9 @@ def write_default_uijson(path, use_initializers=False):
     for filename, params in filedict.items():
 
         if use_initializers:
-            if getattr(params, "forward_only", None) is not None:
+            if type(params) in [OctreeParams, PeakFinderParams]:
+                params.write_input_file(name=filename, path=path)
+            elif getattr(params, "forward_only", None) is not None:
                 params.write_input_file(name=filename, path=path)
         else:
             params.write_input_file(name=filename, path=path, default=True)

--- a/geoapps/io/write_default_uijson.py
+++ b/geoapps/io/write_default_uijson.py
@@ -84,14 +84,8 @@ def write_default_uijson(path, use_initializers=False):
     }
 
     for filename, params in filedict.items():
-
-        if use_initializers:
-            if type(params) in [OctreeParams, PeakFinderParams]:
-                params.write_input_file(name=filename, path=path)
-            elif getattr(params, "forward_only", None) is not None:
-                params.write_input_file(name=filename, path=path)
-        else:
-            params.write_input_file(name=filename, path=path, default=True)
+        default = False if use_initializers else True
+        params.write_input_file(name=filename, path=path, default=default)
 
 
 if __name__ == "__main__":

--- a/geoapps/io/write_default_uijson.py
+++ b/geoapps/io/write_default_uijson.py
@@ -84,8 +84,7 @@ def write_default_uijson(path, use_initializers=False):
     }
 
     for filename, params in filedict.items():
-        default = False if use_initializers else True
-        params.write_input_file(name=filename, path=path, default=default)
+        params.write_input_file(name=filename, path=path, default=not use_initializers)
 
 
 if __name__ == "__main__":

--- a/tests/write_default_uijson_test.py
+++ b/tests/write_default_uijson_test.py
@@ -7,9 +7,24 @@
 
 import os
 
+from geoapps.io import InputFile
+from geoapps.io.Gravity import GravityParams
 from geoapps.io.write_default_uijson import write_default_uijson
 
 
 def test_write_default_uijson(tmp_path):
     write_default_uijson(tmp_path)
-    assert os.path.exists(os.path.join(tmp_path, "gravity_inversion.ui.json"))
+    filepath = os.path.join(tmp_path, "gravity_inversion.ui.json")
+    assert os.path.exists(filepath)
+    ifile = InputFile(filepath)
+    params = GravityParams(ifile, validate=False)
+    assert params.gz_uncertainty == 1.0
+
+
+def test_write_default_uijson_initializers(tmp_path):
+    write_default_uijson(tmp_path, use_initializers=True)
+    filepath = os.path.join(tmp_path, "gravity_inversion.ui.json")
+    assert os.path.exists(filepath)
+    ifile = InputFile(filepath)
+    params = GravityParams(ifile, validate=False)
+    assert params.gz_uncertainty == 0.05


### PR DESCRIPTION
**GEOPY-390 - Add a write_default_ui_json method in root of io module that finds all sub-modules and writes the a defaulted ui.json file for each.**
Requested fix to include peakfinder and octree files when run with use_initializers option