### PR TITLE
GEOPY-442

### DIFF
--- a/geoapps/drivers/components/locations.py
+++ b/geoapps/drivers/components/locations.py
@@ -187,7 +187,7 @@ class InversionLocations:
             if isinstance(self.params.topography, UUID):
                 z = self.workspace.get_entity(self.params.topography)[0].values
             else:
-                z = np.ones_like(locs) * self.params.topography
+                z = np.ones_like(topo[:, 2]) * self.params.topography
 
             topo[:, 2] = z
 

--- a/geoapps/drivers/components/locations.py
+++ b/geoapps/drivers/components/locations.py
@@ -127,7 +127,7 @@ class InversionLocations:
         locs = get_locs(self.workspace, obj)
 
         if locs is None:
-            msg = f"Workspace object {data_object} 'vertices' attribute is None."
+            msg = f"Workspace object {obj} 'vertices' attribute is None."
             msg += " Object type should be Grid2D or point-like."
             raise (ValueError(msg))
 

--- a/geoapps/drivers/components/topography.py
+++ b/geoapps/drivers/components/topography.py
@@ -13,8 +13,11 @@ if TYPE_CHECKING:
     from geoh5py.workspace import Workspace
     from geoapps.io import Params
     from . import InversionMesh
+    from typing import Any
+
 
 from copy import deepcopy
+from uuid import UUID
 
 import numpy as np
 from discretize.utils import active_from_xyz
@@ -110,7 +113,13 @@ class InversionTopography(InversionLocations):
         locs = super().get_locations(uid)
 
         if self.params.topography is not None:
-            elev = self.workspace.get_entity(self.params.topography)[0].values
+            if isinstance(self.params.topography, UUID):
+                elev = self.workspace.get_entity(self.params.topography)[0].values
+            elif isinstance(self.params.topography, (int, float)):
+                elev = np.ones_like(locs[:, 2]) * self.params.topography
+            else:
+                elev = self.params.topography.values  # Must be FloatData at this point
+
             if not np.all(locs[:, 2] == elev):
                 locs[:, 2] = elev
 

--- a/geoapps/drivers/components/topography.py
+++ b/geoapps/drivers/components/topography.py
@@ -64,7 +64,8 @@ class InversionTopography(InversionLocations):
         self.mask = np.ones(len(self.locations), dtype=bool)
 
         topo_window = deepcopy(self.window)
-        topo_window["size"] = [2 * s for s in topo_window["size"]]
+        if topo_window is not None:
+            topo_window["size"] = [2 * s for s in topo_window["size"]]
         self.mask = filter_xy(
             self.locations[:, 0],
             self.locations[:, 1],

--- a/geoapps/io/validators.py
+++ b/geoapps/io/validators.py
@@ -161,21 +161,24 @@ class InputValidator:
             for req in pvalidations["reqs"]:
                 self._validate_parameter_req(param, value, req, chunk)
         if "uuid" in pvalidations.keys():
+
             if isinstance(value, str):
                 try:
                     child_uuid = UUID(value)
                     parent = associations[child_uuid]
                 except (KeyError, TypeError):
                     parent = None
+                self._validate_parameter_uuid(param, value, ws, parent)
+
             elif isinstance(value, UUID):
                 try:
                     parent = associations[value]
                 except (KeyError, TypeError):
                     parent = None
-            else:
-                parent = None
+                self._validate_parameter_uuid(param, value, ws, parent)
 
-            self._validate_parameter_uuid(param, value, ws, parent)
+            else:
+                pass
 
         if "property_groups" in pvalidations.keys():
             try:

--- a/tests/locations_test.py
+++ b/tests/locations_test.py
@@ -98,3 +98,8 @@ def test_z_from_topo(tmp_path):
     locations = InversionLocations(ws, params, window)
     locs = locations.set_z_from_topo(np.array([[315674, 6070832, 0]]))
     assert locs[0, 2] == 326
+
+    params.topography = 320.0
+    locations = InversionLocations(ws, params, window)
+    locs = locations.set_z_from_topo(np.array([[315674, 6070832, 0]]))
+    assert locs[0, 2] == 320.0

--- a/tests/topography_test.py
+++ b/tests/topography_test.py
@@ -1,0 +1,48 @@
+#  Copyright (c) 2022 Mira Geoscience Ltd.
+#
+#  This file is part of geoapps.
+#
+#  geoapps is distributed under the terms and conditions of the MIT License
+#  (see LICENSE file at the root of this source code package).
+
+
+from copy import deepcopy
+
+import numpy as np
+import requests
+import SimPEG
+from geoh5py.objects import Points
+from geoh5py.workspace import Workspace
+
+from geoapps.drivers.base_inversion import InversionDriver
+from geoapps.drivers.components import InversionTopography, InversionWindow
+from geoapps.io.MagneticVector import MagneticVectorParams
+from geoapps.io.MagneticVector.constants import default_ui_json
+from geoapps.utils.testing import Geoh5Tester
+
+geoh5 = Workspace("./FlinFlon.geoh5")
+
+
+def setup_params(tmp):
+    d_u_j = deepcopy(default_ui_json)
+    geotest = Geoh5Tester(geoh5, tmp, "test.geoh5", d_u_j, MagneticVectorParams)
+    geotest.set_param("mesh", "{e334f687-df71-4538-ad28-264e420210b8}")
+    geotest.set_param("data_object", "{538a7eb1-2218-4bec-98cc-0a759aa0ef4f}")
+    geotest.set_param("topography_object", "{ab3c2083-6ea8-4d31-9230-7aad3ec09525}")
+    geotest.set_param("topography", "{a603a762-f6cb-4b21-afda-3160e725bf7d}")
+    return geotest.make()
+
+
+def test_get_locations(tmp_path):
+    ws, params = setup_params(tmp_path)
+    window = InversionWindow(ws, params).window
+    topo = InversionTopography(ws, params, window)
+    locs = topo.get_locations(params.topography_object)
+    np.testing.assert_allclose(
+        locs[:, 2],
+        ws.get_entity(params.topography)[0].values,
+    )
+
+    params.topography = 199.0
+    locs = topo.get_locations(params.topography_object)
+    np.testing.assert_allclose(locs[:, 2], np.ones_like(locs[:, 2]) * 199.0)


### PR DESCRIPTION
**GEOPY-442 - Grav/Mag inversion crash on topo=constant or relative**
Bypass uuid validation if param is int/float.  Also debugged through some problems with the get_locations methods if topography is provided as constant.