### PR TITLE
GEOPY-455

### DIFF
--- a/geoapps/inversion/electricals/direct_current/constants.py
+++ b/geoapps/inversion/electricals/direct_current/constants.py
@@ -236,7 +236,6 @@ validations = {
 app_initializer = {
     "geoh5": "../../../assets/FlinFlon_dcip.geoh5",
     "data_object": UUID("{6e14de2c-9c2f-4976-84c2-b330d869cb82}"),
-    "potential_channel_bool": True,
     "potential_channel": UUID("{502e7256-aafa-4016-969f-5cc3a4f27315}"),
     "potential_uncertainty": UUID("{62746129-3d82-427e-a84c-78cded00c0bc}"),
     "reference_model": 1e-1,

--- a/geoapps/inversion/electricals/induced_polarization/constants.py
+++ b/geoapps/inversion/electricals/induced_polarization/constants.py
@@ -261,7 +261,6 @@ validations = {
 app_initializer = {
     "geoh5": "../../../assets/FlinFlon_dcip.geoh5",
     "data_object": UUID("{6e14de2c-9c2f-4976-84c2-b330d869cb82}"),
-    "chargeability_channel_bool": True,
     "chargeability_channel": UUID("{162320e6-2b80-4877-9ec1-a8f5b6a13673}"),
     "chargeability_uncertainty": 0.001,
     "starting_model": 1e-4,

--- a/geoapps/inversion/potential_fields/application.py
+++ b/geoapps/inversion/potential_fields/application.py
@@ -106,6 +106,7 @@ class InversionApp(PlotSelection2D):
                 self.defaults[key] = value.uid
             else:
                 self.defaults[key] = value
+        self.defaults["tmi_channel_bool"] = True
 
         self.em_system_specs = geophysical_systems.parameters()
         self._data_count = (Label("Data Count: 0"),)

--- a/geoapps/inversion/potential_fields/gravity/constants.py
+++ b/geoapps/inversion/potential_fields/gravity/constants.py
@@ -553,7 +553,6 @@ app_initializer = {
     "geoh5": "../../../assets/FlinFlon.geoh5",
     "forward_only": False,
     "data_object": UUID("{538a7eb1-2218-4bec-98cc-0a759aa0ef4f}"),
-    "gz_channel_bool": True,
     "gz_channel": UUID("{6de9177a-8277-4e17-b76c-2b8b05dcf23c}"),
     "gz_uncertainty": 0.05,
     "u_cell_size": 25.0,

--- a/geoapps/inversion/potential_fields/magnetic_scalar/constants.py
+++ b/geoapps/inversion/potential_fields/magnetic_scalar/constants.py
@@ -580,7 +580,6 @@ app_initializer = {
     "geoh5": "../../assets/FlinFlon.geoh5",
     "forward_only": False,
     "data_object": UUID("{538a7eb1-2218-4bec-98cc-0a759aa0ef4f}"),
-    "tmi_channel_bool": True,
     "tmi_channel": UUID("{44822654-b6ae-45b0-8886-2d845f80f422}"),
     "tmi_uncertainty": 10,
     "inducing_field_strength": 60000.0,

--- a/geoapps/inversion/potential_fields/magnetic_vector/constants.py
+++ b/geoapps/inversion/potential_fields/magnetic_vector/constants.py
@@ -702,7 +702,6 @@ app_initializer = {
     "geoh5": "../../../assets/FlinFlon.geoh5",
     "forward_only": False,
     "data_object": UUID("{538a7eb1-2218-4bec-98cc-0a759aa0ef4f}"),
-    "tmi_channel_bool": True,
     "tmi_channel": UUID("{44822654-b6ae-45b0-8886-2d845f80f422}"),
     "tmi_uncertainty": 10,
     "inducing_field_strength": 60000.0,


### PR DESCRIPTION
**GEOPY-455 - app_initializers contain a channel bool to hotstart the notebook app, but this causes problems when we write inversion ui.json files from the initializers.**
Remove channel bools from app_initializers.  A simple fix to the application to keep the tmi channel populated when initializing the app (nothing needed for the dcip app for some reason).