### PR TITLE
GEOPY-458: Allow both "Vertex" and "Cell" values for "topography"

### DIFF
--- a/geoapps/inversion/constants.py
+++ b/geoapps/inversion/constants.py
@@ -192,7 +192,7 @@ default_ui_json = {
         "value": None,
     },
     "topography": {
-        "association": "Vertex",
+        "association": ["Vertex", "Cell"],
         "dataType": "Float",
         "group": "Topography",
         "main": True,


### PR DESCRIPTION
**GEOPY-458 - Allow both "Vertex" and "Cell" values for "topography"**
