### PR TITLE
GEOPY-682: back to Python 3.9 for installation

### DIFF
--- a/.github/workflows/create_env_file.yml
+++ b/.github/workflows/create_env_file.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: windows-latest
     env:
       releaseFullEnv: false
-      python_ver: '3.10'
+      python_ver: '3.9'
       PYTHONUTF8: 1
       ARTIFACT_NAME: geoapps.conda-env
       CONDA_ENV_FILE_GLOB_PATTERN: conda-py-*-geoapps*.lock.yml

--- a/.github/workflows/pytest-windows.yaml
+++ b/.github/workflows/pytest-windows.yaml
@@ -45,7 +45,7 @@ jobs:
         run: |
           pytest --cov=${source_dir} --cov-report=xml --cov-branch
       - name: Codecov
-        if: ${{ success() && matrix.python_ver == '3.10' }}
+        if: ${{ success() && matrix.python_ver == '3.9' }}
         uses: codecov/codecov-action@v3
         with:
           name: GitHub

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -28,7 +28,7 @@ jobs:
         shell: bash -l {0}
     env:
       PYTHONUTF8: 1
-      CONDA_LOCK_ENV_FILE: environments/conda-py-3.10-win-64-dev.lock.yml
+      CONDA_LOCK_ENV_FILE: environments/conda-py-3.9-win-64-dev.lock.yml
     steps:
       - uses: actions/checkout@v3
       - name: Setup conda env

--- a/Install_or_Update.bat
+++ b/Install_or_Update.bat
@@ -6,7 +6,7 @@ if !errorlevel! neq 0 (
   exit /B !errorlevel!
 )
 
-set PY_VER=3.10
+set PY_VER=3.9
 
 set MY_CONDA=!MY_CONDA_EXE:"=!
 cd %~dp0

--- a/devtools/create_application_env_files.py
+++ b/devtools/create_application_env_files.py
@@ -44,7 +44,7 @@ def create_standalone_lock(git_url: str, extras=[], suffix=""):
     print(
         f"# Creating lock file for stand-alone environment (extras={','.join(extras)})..."
     )
-    py_ver = "3.10"
+    py_ver = "3.9"
     platform = "win-64"
     base_filename = f"conda-py-{py_ver}-{platform}{suffix}"
     initial_lock_file = Path(f"environments/{base_filename}-tmp.lock.yml")

--- a/devtools/setup-dev.bat
+++ b/devtools/setup-dev.bat
@@ -17,7 +17,7 @@ if !errorlevel! neq 0 (
   exit /B !errorlevel!
 )
 
-set PY_VER=3.10
+set PY_VER=3.9
 
 set env_path=%project_dir%\.conda-env
 call !MY_CONDA_EXE! activate


### PR DESCRIPTION
**GEOPY-682 - geoapps 0.9.0 yml file for analyst simpeg fails to install**
no strong reason for moving to 3.10

Anaconda and Miniconda are still using 3.9 for the base environment