### PR TITLE
GEOPY-824: use Python 3.10 as default runtime environment

### DIFF
--- a/.github/workflows/create_env_file.yml
+++ b/.github/workflows/create_env_file.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: windows-latest
     env:
       releaseFullEnv: false
-      python_ver: '3.9'
+      python_ver: '3.10'
       PYTHONUTF8: 1
       ARTIFACT_NAME: geoapps.conda-env
       CONDA_ENV_FILE_GLOB_PATTERN: conda-py-*-geoapps*.lock.yml

--- a/Install_or_Update.bat
+++ b/Install_or_Update.bat
@@ -6,7 +6,7 @@ if !errorlevel! neq 0 (
   exit /B !errorlevel!
 )
 
-set PY_VER=3.9
+set PY_VER=3.10
 
 set MY_CONDA=!MY_CONDA_EXE:"=!
 cd %~dp0

--- a/devtools/setup-dev.bat
+++ b/devtools/setup-dev.bat
@@ -17,7 +17,7 @@ if !errorlevel! neq 0 (
   exit /B !errorlevel!
 )
 
-set PY_VER=3.9
+set PY_VER=3.10
 
 set env_path=%project_dir%\.conda-env
 call !MY_CONDA_EXE! activate


### PR DESCRIPTION
**GEOPY-824 - use Python 3.10 as default run environment**
