### PR TITLE
GEOPY-834: kill running github actions the same PR

### DIFF
--- a/.github/workflows/pytest-unix-os.yaml
+++ b/.github/workflows/pytest-unix-os.yaml
@@ -16,6 +16,10 @@ on:
       - feature/**
       - hotfix/**
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 env:
   source_dir: geoapps
 

--- a/.github/workflows/pytest-windows.yaml
+++ b/.github/workflows/pytest-windows.yaml
@@ -16,6 +16,10 @@ on:
       - feature/**
       - hotfix/**
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 env:
   source_dir: geoapps
 

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -16,6 +16,10 @@ on:
       - feature/**
       - hotfix/**
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 env:
   source_dir: geoapps
 


### PR DESCRIPTION
**GEOPY-834 - kill running github actions upon new commit**

Same changes as in https://github.com/MiraGeoscience/geoh5py/pull/285