### PR TITLE
GEOPY-824: create the application env file for Python 3.10 - fixup

### DIFF
--- a/devtools/create_application_env_files.py
+++ b/devtools/create_application_env_files.py
@@ -44,7 +44,7 @@ def create_standalone_lock(git_url: str, extras=[], suffix=""):
     print(
         f"# Creating lock file for stand-alone environment (extras={','.join(extras)})..."
     )
-    py_ver = "3.9"
+    py_ver = "3.10"
     platform = "win-64"
     base_filename = f"conda-py-{py_ver}-{platform}{suffix}"
     initial_lock_file = Path(f"environments/{base_filename}-tmp.lock.yml")


### PR DESCRIPTION
**GEOPY-824 - use Python 3.10 as default run environment**
fix Python version to 3.10 in the generated environment file for the application