### PR TITLE
GEOPY-888: do not enforce libmamba as conda solver

### DIFF
--- a/Install_or_Update.bat
+++ b/Install_or_Update.bat
@@ -14,11 +14,6 @@ set MY_CONDA=!MY_CONDA_EXE:"=!
 cd %~dp0
 set PYTHONUTF8=1
 
-:: try installing libmamba solver in base environment (fail silently)
-call !MY_CONDA! install -n base --override-channels -c conda-forge conda-libmamba-solver -y > nul 2>&1 ^
-  && set "CONDA_SOLVER=libmamba" ^
-  || (call )
-
 call "!MY_CONDA!" activate base ^
   && call conda env create --force -n %ENV_NAME% --file environments\conda-py-%PY_VER%-win-64.lock.yml ^
   && call conda run -n %ENV_NAME% pip install -e . --no-deps

--- a/devtools/setup-conda-base.bat
+++ b/devtools/setup-conda-base.bat
@@ -1,4 +1,4 @@
-:: Setup the conda base environment with the conda libmamba solver, conda-lock and conda-pack
+:: Setup the conda base environment with conda-lock
 ::
 :: The script has no parameters, and can be executed by double-clicking
 :: the .bat file from Windows Explorer.
@@ -15,8 +15,7 @@ if !errorlevel! neq 0 (
   exit /B !errorlevel!
 )
 
-call !MY_CONDA_EXE! install -n base --override-channels -c conda-forge conda-libmamba-solver -y ^
-  && call !MY_CONDA_EXE! run -n base pip install conda-lock[pip_support]
+call !MY_CONDA_EXE! run -n base pip install conda-lock[pip_support]
 
 if !errorlevel! neq 0 (
   echo "** ERROR: Installation failed **"

--- a/devtools/setup-dev.bat
+++ b/devtools/setup-dev.bat
@@ -22,7 +22,7 @@ set PY_VER=3.10
 
 set env_path=%project_dir%\.conda-env
 call !MY_CONDA_EXE! activate base ^
-  && call conda env update --solver=libmamba -p %env_path% --file %project_dir%\environments\conda-py-%PY_VER%-win-64-dev.lock.yml
+  && call conda env update %env_path% --file %project_dir%\environments\conda-py-%PY_VER%-win-64-dev.lock.yml
 
 if !errorlevel! neq 0 (
   pause


### PR DESCRIPTION
**GEOPY-888 - libmamba in install script makes the installation stall for some configuration**
libmamba is a faster solver for conda, but seems to fail depending  on the conda installation

(To learn more about libmamba solver:  [A Faster Solver for Conda: Libmamba](https://www.anaconda.com/blog/a-faster-conda-for-a-growing-community) )