### PR TITLE
GEOPY-912: start_notebook script not found in some instances

### DIFF
--- a/Start_applications.bat
+++ b/Start_applications.bat
@@ -10,5 +10,5 @@ if !errorlevel! neq 0 (
 set ENV_NAME=geoapps
 
 set MY_CONDA=!MY_CONDA_EXE:"=!
-call "!MY_CONDA!" run -n %ENV_NAME% start_notebook
+call "!MY_CONDA!" run -n %ENV_NAME% python -m geoapps.scripts.start_notebook
 cmd /k "!MY_CONDA!" activate %ENV_NAME%


### PR DESCRIPTION
**GEOPY-912 - start_notebook script not found in some instances**

Do not assume `start_notebook` script is in path.
When installing geoapps, start_notebook is supposed to be exposed as an executable script in the environment. It seems not be the case sometimes. Just call the python module directly instead.