### PR TITLE
GEOPY-937: update lock files to pointing to mira-omf 3.0.0-rc.4

### DIFF
--- a/conda-py-3.10-lock.yml
+++ b/conda-py-3.10-lock.yml
@@ -4670,13 +4670,13 @@ package:
     six: '>=1.16,<2.0'
     vectormath: '>=0.2.0,<0.3.0'
   hash:
-    sha256: 42f4fa2cd29c11d0abef74809dfcb587fb96a048a3c619ff78683c82c6264df4
+    sha256: 408259d5c4d3db92ba43192be9e2609dd77256873aaf871353035299c5403f28
   manager: pip
   name: mira-omf
   optional: false
   platform: linux-64
-  url: https://files.pythonhosted.org/packages/d4/9d/2e7a1d1972cd1aa156b319565b118c79b9141a1b772c63310d3551371929/mira_omf-3.0.0rc3-py3-none-any.whl
-  version: 3.0.0rc3
+  url: https://files.pythonhosted.org/packages/af/32/5528f983e93452401037d61856cd83a45f44dfcbe424f03895fb12ac54f6/mira_omf-3.0.0rc4-py3-none-any.whl
+  version: 3.0.0rc4
 - category: core
   dependencies:
     discretize: '>=0.7.0'
@@ -8999,13 +8999,13 @@ package:
     six: '>=1.16,<2.0'
     vectormath: '>=0.2.0,<0.3.0'
   hash:
-    sha256: 42f4fa2cd29c11d0abef74809dfcb587fb96a048a3c619ff78683c82c6264df4
+    sha256: 408259d5c4d3db92ba43192be9e2609dd77256873aaf871353035299c5403f28
   manager: pip
   name: mira-omf
   optional: false
   platform: osx-64
-  url: https://files.pythonhosted.org/packages/d4/9d/2e7a1d1972cd1aa156b319565b118c79b9141a1b772c63310d3551371929/mira_omf-3.0.0rc3-py3-none-any.whl
-  version: 3.0.0rc3
+  url: https://files.pythonhosted.org/packages/af/32/5528f983e93452401037d61856cd83a45f44dfcbe424f03895fb12ac54f6/mira_omf-3.0.0rc4-py3-none-any.whl
+  version: 3.0.0rc4
 - category: core
   dependencies:
     discretize: '>=0.7.0'
@@ -13539,13 +13539,13 @@ package:
     six: '>=1.16,<2.0'
     vectormath: '>=0.2.0,<0.3.0'
   hash:
-    sha256: 42f4fa2cd29c11d0abef74809dfcb587fb96a048a3c619ff78683c82c6264df4
+    sha256: 408259d5c4d3db92ba43192be9e2609dd77256873aaf871353035299c5403f28
   manager: pip
   name: mira-omf
   optional: false
   platform: win-64
-  url: https://files.pythonhosted.org/packages/d4/9d/2e7a1d1972cd1aa156b319565b118c79b9141a1b772c63310d3551371929/mira_omf-3.0.0rc3-py3-none-any.whl
-  version: 3.0.0rc3
+  url: https://files.pythonhosted.org/packages/af/32/5528f983e93452401037d61856cd83a45f44dfcbe424f03895fb12ac54f6/mira_omf-3.0.0rc4-py3-none-any.whl
+  version: 3.0.0rc4
 - category: core
   dependencies:
     discretize: '>=0.7.0'

--- a/conda-py-3.9-lock.yml
+++ b/conda-py-3.9-lock.yml
@@ -4684,13 +4684,13 @@ package:
     six: '>=1.16,<2.0'
     vectormath: '>=0.2.0,<0.3.0'
   hash:
-    sha256: 42f4fa2cd29c11d0abef74809dfcb587fb96a048a3c619ff78683c82c6264df4
+    sha256: 408259d5c4d3db92ba43192be9e2609dd77256873aaf871353035299c5403f28
   manager: pip
   name: mira-omf
   optional: false
   platform: linux-64
-  url: https://files.pythonhosted.org/packages/d4/9d/2e7a1d1972cd1aa156b319565b118c79b9141a1b772c63310d3551371929/mira_omf-3.0.0rc3-py3-none-any.whl
-  version: 3.0.0rc3
+  url: https://files.pythonhosted.org/packages/af/32/5528f983e93452401037d61856cd83a45f44dfcbe424f03895fb12ac54f6/mira_omf-3.0.0rc4-py3-none-any.whl
+  version: 3.0.0rc4
 - category: core
   dependencies:
     discretize: '>=0.7.0'
@@ -9027,13 +9027,13 @@ package:
     six: '>=1.16,<2.0'
     vectormath: '>=0.2.0,<0.3.0'
   hash:
-    sha256: 42f4fa2cd29c11d0abef74809dfcb587fb96a048a3c619ff78683c82c6264df4
+    sha256: 408259d5c4d3db92ba43192be9e2609dd77256873aaf871353035299c5403f28
   manager: pip
   name: mira-omf
   optional: false
   platform: osx-64
-  url: https://files.pythonhosted.org/packages/d4/9d/2e7a1d1972cd1aa156b319565b118c79b9141a1b772c63310d3551371929/mira_omf-3.0.0rc3-py3-none-any.whl
-  version: 3.0.0rc3
+  url: https://files.pythonhosted.org/packages/af/32/5528f983e93452401037d61856cd83a45f44dfcbe424f03895fb12ac54f6/mira_omf-3.0.0rc4-py3-none-any.whl
+  version: 3.0.0rc4
 - category: core
   dependencies:
     discretize: '>=0.7.0'
@@ -13581,13 +13581,13 @@ package:
     six: '>=1.16,<2.0'
     vectormath: '>=0.2.0,<0.3.0'
   hash:
-    sha256: 42f4fa2cd29c11d0abef74809dfcb587fb96a048a3c619ff78683c82c6264df4
+    sha256: 408259d5c4d3db92ba43192be9e2609dd77256873aaf871353035299c5403f28
   manager: pip
   name: mira-omf
   optional: false
   platform: win-64
-  url: https://files.pythonhosted.org/packages/d4/9d/2e7a1d1972cd1aa156b319565b118c79b9141a1b772c63310d3551371929/mira_omf-3.0.0rc3-py3-none-any.whl
-  version: 3.0.0rc3
+  url: https://files.pythonhosted.org/packages/af/32/5528f983e93452401037d61856cd83a45f44dfcbe424f03895fb12ac54f6/mira_omf-3.0.0rc4-py3-none-any.whl
+  version: 3.0.0rc4
 - category: core
   dependencies:
     discretize: '>=0.7.0'

--- a/devtools/add_url_tag_sha256.py
+++ b/devtools/add_url_tag_sha256.py
@@ -56,7 +56,7 @@ def patch_pyproject_toml() -> None:
         return
 
     tag_url_re = re.compile(
-        r"""^(\s*\S*\s*=\s*{\s*url\s*=\s*)"(.*/archive/refs/tags/.*)#sha256=\w*"(.*}.*)"""
+        r"""^(\s*[^#]\S+\s*=\s*{\s*url\s*=\s*)"(.*/archive/refs/tags/.*)#sha256=\w*"(.*}.*)"""
     )
     pyproject_sha = Path("pyproject-sha.toml")
     with open(pyproject_sha, "w") as patched:
@@ -79,7 +79,7 @@ def patch_pyproject_toml() -> None:
 
 def has_git_branches(pyproject: Path) -> bool:
     branch_url_re = re.compile(
-        r"""^(\s*\S*\s*=\s*{\s*url\s*=\s*)"(.*/archive/refs/heads/.*)\S*"(.*}.*)"""
+        r"""^(\s*[^#]\S+\s*=\s*{\s*url\s*=\s*)"(.*/archive/refs/heads/.*)\S*"(.*}.*)"""
     )
     with open(pyproject) as input:
         for line in input:

--- a/environments/conda-py-3.10-linux-64-dev.lock.yml
+++ b/environments/conda-py-3.10-linux-64-dev.lock.yml
@@ -324,7 +324,7 @@ dependencies:
   - pip:
     - geoh5py === 0.7.0rc5 --hash=sha256:b6763f11d14d1482c465f3c0ce3762ac6e45d126bc0168764b959b942c5c9d19
     - simpeg-archive === 0.9.1.dev5 --hash=sha256:44fb910c849577dd892f40b39289d26f14c3c5bd50467ed1b41b7841b66d4403
-    - mira-omf === 3.0.0rc3 --hash=sha256:42f4fa2cd29c11d0abef74809dfcb587fb96a048a3c619ff78683c82c6264df4
+    - mira-omf === 3.0.0rc4 --hash=sha256:408259d5c4d3db92ba43192be9e2609dd77256873aaf871353035299c5403f28
     - mira-simpeg === 0.15.1.dev9 --hash=sha256:e6cfc09e1d9fb995de81714bb0d76a6399a174e9974aba473321324a8b20671a
     - param-sweeps === 0.1.5rc1 --hash=sha256:fd40348f6685dbea6d8d61e92bbee12ab6f84df90bc18032d66486f474fe748d
 

--- a/environments/conda-py-3.10-linux-64.lock.yml
+++ b/environments/conda-py-3.10-linux-64.lock.yml
@@ -304,7 +304,7 @@ dependencies:
   - pip:
     - geoh5py === 0.7.0rc5 --hash=sha256:b6763f11d14d1482c465f3c0ce3762ac6e45d126bc0168764b959b942c5c9d19
     - simpeg-archive === 0.9.1.dev5 --hash=sha256:44fb910c849577dd892f40b39289d26f14c3c5bd50467ed1b41b7841b66d4403
-    - mira-omf === 3.0.0rc3 --hash=sha256:42f4fa2cd29c11d0abef74809dfcb587fb96a048a3c619ff78683c82c6264df4
+    - mira-omf === 3.0.0rc4 --hash=sha256:408259d5c4d3db92ba43192be9e2609dd77256873aaf871353035299c5403f28
     - mira-simpeg === 0.15.1.dev9 --hash=sha256:e6cfc09e1d9fb995de81714bb0d76a6399a174e9974aba473321324a8b20671a
     - param-sweeps === 0.1.5rc1 --hash=sha256:fd40348f6685dbea6d8d61e92bbee12ab6f84df90bc18032d66486f474fe748d
 

--- a/environments/conda-py-3.10-osx-64-dev.lock.yml
+++ b/environments/conda-py-3.10-osx-64-dev.lock.yml
@@ -308,7 +308,7 @@ dependencies:
   - pip:
     - geoh5py === 0.7.0rc5 --hash=sha256:b6763f11d14d1482c465f3c0ce3762ac6e45d126bc0168764b959b942c5c9d19
     - simpeg-archive === 0.9.1.dev5 --hash=sha256:44fb910c849577dd892f40b39289d26f14c3c5bd50467ed1b41b7841b66d4403
-    - mira-omf === 3.0.0rc3 --hash=sha256:42f4fa2cd29c11d0abef74809dfcb587fb96a048a3c619ff78683c82c6264df4
+    - mira-omf === 3.0.0rc4 --hash=sha256:408259d5c4d3db92ba43192be9e2609dd77256873aaf871353035299c5403f28
     - mira-simpeg === 0.15.1.dev9 --hash=sha256:e6cfc09e1d9fb995de81714bb0d76a6399a174e9974aba473321324a8b20671a
     - param-sweeps === 0.1.5rc1 --hash=sha256:fd40348f6685dbea6d8d61e92bbee12ab6f84df90bc18032d66486f474fe748d
 

--- a/environments/conda-py-3.10-osx-64.lock.yml
+++ b/environments/conda-py-3.10-osx-64.lock.yml
@@ -288,7 +288,7 @@ dependencies:
   - pip:
     - geoh5py === 0.7.0rc5 --hash=sha256:b6763f11d14d1482c465f3c0ce3762ac6e45d126bc0168764b959b942c5c9d19
     - simpeg-archive === 0.9.1.dev5 --hash=sha256:44fb910c849577dd892f40b39289d26f14c3c5bd50467ed1b41b7841b66d4403
-    - mira-omf === 3.0.0rc3 --hash=sha256:42f4fa2cd29c11d0abef74809dfcb587fb96a048a3c619ff78683c82c6264df4
+    - mira-omf === 3.0.0rc4 --hash=sha256:408259d5c4d3db92ba43192be9e2609dd77256873aaf871353035299c5403f28
     - mira-simpeg === 0.15.1.dev9 --hash=sha256:e6cfc09e1d9fb995de81714bb0d76a6399a174e9974aba473321324a8b20671a
     - param-sweeps === 0.1.5rc1 --hash=sha256:fd40348f6685dbea6d8d61e92bbee12ab6f84df90bc18032d66486f474fe748d
 

--- a/environments/conda-py-3.10-win-64-dev.lock.yml
+++ b/environments/conda-py-3.10-win-64-dev.lock.yml
@@ -305,7 +305,7 @@ dependencies:
   - pip:
     - geoh5py === 0.7.0rc5 --hash=sha256:b6763f11d14d1482c465f3c0ce3762ac6e45d126bc0168764b959b942c5c9d19
     - simpeg-archive === 0.9.1.dev5 --hash=sha256:44fb910c849577dd892f40b39289d26f14c3c5bd50467ed1b41b7841b66d4403
-    - mira-omf === 3.0.0rc3 --hash=sha256:42f4fa2cd29c11d0abef74809dfcb587fb96a048a3c619ff78683c82c6264df4
+    - mira-omf === 3.0.0rc4 --hash=sha256:408259d5c4d3db92ba43192be9e2609dd77256873aaf871353035299c5403f28
     - mira-simpeg === 0.15.1.dev9 --hash=sha256:e6cfc09e1d9fb995de81714bb0d76a6399a174e9974aba473321324a8b20671a
     - param-sweeps === 0.1.5rc1 --hash=sha256:fd40348f6685dbea6d8d61e92bbee12ab6f84df90bc18032d66486f474fe748d
 

--- a/environments/conda-py-3.10-win-64.lock.yml
+++ b/environments/conda-py-3.10-win-64.lock.yml
@@ -285,7 +285,7 @@ dependencies:
   - pip:
     - geoh5py === 0.7.0rc5 --hash=sha256:b6763f11d14d1482c465f3c0ce3762ac6e45d126bc0168764b959b942c5c9d19
     - simpeg-archive === 0.9.1.dev5 --hash=sha256:44fb910c849577dd892f40b39289d26f14c3c5bd50467ed1b41b7841b66d4403
-    - mira-omf === 3.0.0rc3 --hash=sha256:42f4fa2cd29c11d0abef74809dfcb587fb96a048a3c619ff78683c82c6264df4
+    - mira-omf === 3.0.0rc4 --hash=sha256:408259d5c4d3db92ba43192be9e2609dd77256873aaf871353035299c5403f28
     - mira-simpeg === 0.15.1.dev9 --hash=sha256:e6cfc09e1d9fb995de81714bb0d76a6399a174e9974aba473321324a8b20671a
     - param-sweeps === 0.1.5rc1 --hash=sha256:fd40348f6685dbea6d8d61e92bbee12ab6f84df90bc18032d66486f474fe748d
 

--- a/environments/conda-py-3.9-linux-64-dev.lock.yml
+++ b/environments/conda-py-3.9-linux-64-dev.lock.yml
@@ -325,7 +325,7 @@ dependencies:
   - pip:
     - geoh5py === 0.7.0rc5 --hash=sha256:b6763f11d14d1482c465f3c0ce3762ac6e45d126bc0168764b959b942c5c9d19
     - simpeg-archive === 0.9.1.dev5 --hash=sha256:44fb910c849577dd892f40b39289d26f14c3c5bd50467ed1b41b7841b66d4403
-    - mira-omf === 3.0.0rc3 --hash=sha256:42f4fa2cd29c11d0abef74809dfcb587fb96a048a3c619ff78683c82c6264df4
+    - mira-omf === 3.0.0rc4 --hash=sha256:408259d5c4d3db92ba43192be9e2609dd77256873aaf871353035299c5403f28
     - mira-simpeg === 0.15.1.dev9 --hash=sha256:e6cfc09e1d9fb995de81714bb0d76a6399a174e9974aba473321324a8b20671a
     - param-sweeps === 0.1.5rc1 --hash=sha256:fd40348f6685dbea6d8d61e92bbee12ab6f84df90bc18032d66486f474fe748d
 

--- a/environments/conda-py-3.9-linux-64.lock.yml
+++ b/environments/conda-py-3.9-linux-64.lock.yml
@@ -305,7 +305,7 @@ dependencies:
   - pip:
     - geoh5py === 0.7.0rc5 --hash=sha256:b6763f11d14d1482c465f3c0ce3762ac6e45d126bc0168764b959b942c5c9d19
     - simpeg-archive === 0.9.1.dev5 --hash=sha256:44fb910c849577dd892f40b39289d26f14c3c5bd50467ed1b41b7841b66d4403
-    - mira-omf === 3.0.0rc3 --hash=sha256:42f4fa2cd29c11d0abef74809dfcb587fb96a048a3c619ff78683c82c6264df4
+    - mira-omf === 3.0.0rc4 --hash=sha256:408259d5c4d3db92ba43192be9e2609dd77256873aaf871353035299c5403f28
     - mira-simpeg === 0.15.1.dev9 --hash=sha256:e6cfc09e1d9fb995de81714bb0d76a6399a174e9974aba473321324a8b20671a
     - param-sweeps === 0.1.5rc1 --hash=sha256:fd40348f6685dbea6d8d61e92bbee12ab6f84df90bc18032d66486f474fe748d
 

--- a/environments/conda-py-3.9-osx-64-dev.lock.yml
+++ b/environments/conda-py-3.9-osx-64-dev.lock.yml
@@ -309,7 +309,7 @@ dependencies:
   - pip:
     - geoh5py === 0.7.0rc5 --hash=sha256:b6763f11d14d1482c465f3c0ce3762ac6e45d126bc0168764b959b942c5c9d19
     - simpeg-archive === 0.9.1.dev5 --hash=sha256:44fb910c849577dd892f40b39289d26f14c3c5bd50467ed1b41b7841b66d4403
-    - mira-omf === 3.0.0rc3 --hash=sha256:42f4fa2cd29c11d0abef74809dfcb587fb96a048a3c619ff78683c82c6264df4
+    - mira-omf === 3.0.0rc4 --hash=sha256:408259d5c4d3db92ba43192be9e2609dd77256873aaf871353035299c5403f28
     - mira-simpeg === 0.15.1.dev9 --hash=sha256:e6cfc09e1d9fb995de81714bb0d76a6399a174e9974aba473321324a8b20671a
     - param-sweeps === 0.1.5rc1 --hash=sha256:fd40348f6685dbea6d8d61e92bbee12ab6f84df90bc18032d66486f474fe748d
 

--- a/environments/conda-py-3.9-osx-64.lock.yml
+++ b/environments/conda-py-3.9-osx-64.lock.yml
@@ -289,7 +289,7 @@ dependencies:
   - pip:
     - geoh5py === 0.7.0rc5 --hash=sha256:b6763f11d14d1482c465f3c0ce3762ac6e45d126bc0168764b959b942c5c9d19
     - simpeg-archive === 0.9.1.dev5 --hash=sha256:44fb910c849577dd892f40b39289d26f14c3c5bd50467ed1b41b7841b66d4403
-    - mira-omf === 3.0.0rc3 --hash=sha256:42f4fa2cd29c11d0abef74809dfcb587fb96a048a3c619ff78683c82c6264df4
+    - mira-omf === 3.0.0rc4 --hash=sha256:408259d5c4d3db92ba43192be9e2609dd77256873aaf871353035299c5403f28
     - mira-simpeg === 0.15.1.dev9 --hash=sha256:e6cfc09e1d9fb995de81714bb0d76a6399a174e9974aba473321324a8b20671a
     - param-sweeps === 0.1.5rc1 --hash=sha256:fd40348f6685dbea6d8d61e92bbee12ab6f84df90bc18032d66486f474fe748d
 

--- a/environments/conda-py-3.9-win-64.lock.yml
+++ b/environments/conda-py-3.9-win-64.lock.yml
@@ -286,7 +286,7 @@ dependencies:
   - pip:
     - geoh5py === 0.7.0rc5 --hash=sha256:b6763f11d14d1482c465f3c0ce3762ac6e45d126bc0168764b959b942c5c9d19
     - simpeg-archive === 0.9.1.dev5 --hash=sha256:44fb910c849577dd892f40b39289d26f14c3c5bd50467ed1b41b7841b66d4403
-    - mira-omf === 3.0.0rc3 --hash=sha256:42f4fa2cd29c11d0abef74809dfcb587fb96a048a3c619ff78683c82c6264df4
+    - mira-omf === 3.0.0rc4 --hash=sha256:408259d5c4d3db92ba43192be9e2609dd77256873aaf871353035299c5403f28
     - mira-simpeg === 0.15.1.dev9 --hash=sha256:e6cfc09e1d9fb995de81714bb0d76a6399a174e9974aba473321324a8b20671a
     - param-sweeps === 0.1.5rc1 --hash=sha256:fd40348f6685dbea6d8d61e92bbee12ab6f84df90bc18032d66486f474fe748d
 


### PR DESCRIPTION
**GEOPY-937 - lock files still pointing to mira-omf 3.0.0-rc3 instead of rc.4**
