### PR TITLE
GEOPY-1113: Limit sensitivity storage to RAM on tem inversion

### DIFF
--- a/geoapps/inversion/electromagnetics/time_domain/constants.py
+++ b/geoapps/inversion/electromagnetics/time_domain/constants.py
@@ -272,6 +272,13 @@ default_ui_json = {
         "value": 100.0,
         "enabled": False,
     },
+    "store_sensitivities": {
+        "choiceList": ["ram"],
+        "group": "Compute",
+        "label": "Storage device",
+        "tooltip": "Only RAM storage available for now.",
+        "value": "ram",
+    },
 }
 default_ui_json = dict(base_default_ui_json, **default_ui_json)
 validations = {


### PR DESCRIPTION
**GEOPY-1113 - Remove disk storage option to TEM inversion until fix is found**
