### PR TITLE
GEOPY-1245 - update kmeans to ensure the clusters are always the same.

### DIFF
--- a/geoapps/clustering/driver.py
+++ b/geoapps/clustering/driver.py
@@ -92,10 +92,15 @@ class ClusteringDriver(BaseDriver):
 
                 # Create a mapping from original labels to new labels based on sorted cluster centers
                 sorted_centroids_indices = np.argsort(cluster_centers.sum(axis=1))
-                label_mapping = {old_label: new_label for new_label, old_label in enumerate(sorted_centroids_indices)}
+                label_mapping = {
+                    old_label: new_label
+                    for new_label, old_label in enumerate(sorted_centroids_indices)
+                }
 
                 # Apply the mapping to get new labels
-                new_labels = np.array([label_mapping[label] for label in original_labels])
+                new_labels = np.array(
+                    [label_mapping[label] for label in original_labels]
+                )
 
                 kmeans_dict = {
                     "labels": new_labels.astype(float),

--- a/geoapps/clustering/driver.py
+++ b/geoapps/clustering/driver.py
@@ -244,7 +244,7 @@ class ClusteringDriver(BaseDriver):
                 colorpicker = color_pickers[ii]
                 color = colorpicker.lstrip("#")
                 group_map[ii + 1] = f"Cluster_{ii}"
-                color_map += [[ii + 1] + hex_to_rgb(color) + [1]]
+                color_map += [[ii + 1] + hex_to_rgb(color) + [0]]
 
             color_map = np.core.records.fromarrays(
                 np.vstack(color_map).T,


### PR DESCRIPTION
**GEOPY-1245 - Clustering: Group IDs in application don't match output**
The issue cames from the order of the cluster, which was random even if the seed was fixed. ordering the ids of the clusters based on their values fix the issue.