### PR TITLE
GEOPY-1445: force libmamba solver

### DIFF
--- a/Install_or_Update.bat
+++ b/Install_or_Update.bat
@@ -26,7 +26,7 @@ if not exist %MY_CONDA_ENV_FILE% (
 )
 
 call "!MY_CONDA!" activate base ^
-  && call "!MY_CONDA!" env create --force -n %ENV_NAME% --file %MY_CONDA_ENV_FILE% ^
+  && call "!MY_CONDA!" env create -y --solver libmamba -n %ENV_NAME% --file %MY_CONDA_ENV_FILE% ^
   && call "!MY_CONDA!" run -n %ENV_NAME% pip install --upgrade --force-reinstall .[core,apps]
 
 if !errorlevel! neq 0 (

--- a/README.rst
+++ b/README.rst
@@ -94,7 +94,7 @@ You can install the package using ``conda`` and the ``.lock`` files from a conda
 
 .. code-block:: bash
 
-  conda env create -n my-env -f environments/[the_desired_env].lock.yml
+  conda env create --solver libmamba -n my-env -f environments/[the_desired_env].lock.yml
 
 Install with PyPI
 -----------------

--- a/devtools/setup-dev.bat
+++ b/devtools/setup-dev.bat
@@ -31,7 +31,7 @@ set PIP_EXTRA_INDEX_URL=https://test.pypi.org/simple/
 
 set env_path=%project_dir%\.conda-env
 call !MY_CONDA_EXE! activate base ^
-  && call !MY_CONDA_EXE! env update -p %env_path% --file %project_dir%\environments\py-%PY_VER%-win-64-dev.conda.lock.yml
+  && call !MY_CONDA_EXE! env update --solver libmamba -p %env_path% --file %project_dir%\environments\py-%PY_VER%-win-64-dev.conda.lock.yml
 
 if !errorlevel! neq 0 (
   pause


### PR DESCRIPTION
**GEOPY-1445 - apply latest version of python-conda-template to geoapps**
also requires newer version of Conda which accepts "-y" option instead of "--force"

Applying same changes as in the template repo: https://github.com/MiraGeoscience/python-conda-template/pull/21