### PR TITLE
GEOPY-1712: Exclude RUF005 flag

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -169,6 +169,7 @@ ignore = [
     "C416", # TO DO
     "C419", # TO DO
     "C901", # TO DO
+    "RUF005",  # collection-literal-concatenation - wrong suggestion with numpy arrays
     "RUF012", # TO DO
     "RUF013", # TO DO
     "RUF015", # TO DO


### PR DESCRIPTION
**GEOPY-1712 - disable RUF005 as it is wrong with numpy array**
