### PR TITLE
DEVOPS-1066: ci: rename dependabot group mirageo-ci-actions to mirageo-ci-tools

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,7 +14,7 @@ updates:
       github-actions:
         patterns:
           - actions/*
-      mirageo-ci-actions:
+      mirageo-ci-tools:
         patterns:
           - MiraGeoscience/CI-tools/.github/actions/*
           - MiraGeoscience/CI-tools/.github/workflows/*


### PR DESCRIPTION
**DEVOPS-1066 - use CI-tools v3 in all the repos**
Rename the dependabot group mirageo-ci-actions to mirageo-ci-tools for clarity.

This PR is authored by GitHub Copilot as part of DEVOPS-1066.