### PR TITLE
[WIP] DEVOPS-1133: Pin GitHub Actions to commit hashes

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,17 @@
+name: Dependabot auto-merge
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  call-workflow-dependabot-auto-merge:
+    uses: MiraGeoscience/CI-tools/.github/workflows/reusable-dependabot-auto-merge.yml@7241532854727d993872b67fc761139b8438615b # v3.12.0
+    permissions:
+      contents: write
+      pull-requests: write
+      statuses: write
+      checks: read
+    with:
+      dependabot-groups: mirageo-ci-tools,pre-commit-hooks
+      checks-to-skip: 'pre-commit.ci - pr,CodeQL,codecov/patch,codecov/project'

--- a/.github/workflows/issue_to_jira.yml
+++ b/.github/workflows/issue_to_jira.yml
@@ -12,14 +12,14 @@ jobs:
 
     steps:
     - name: JIRA Login
-      uses: atlassian/gajira-login@v3.0.1
+      uses: atlassian/gajira-login@45fd029b9f1d6d8926c6f04175aa80c0e42c9026 # v3.0.1
       env:
         JIRA_BASE_URL: ${{ secrets.JIRA_BASE_URL }}
         JIRA_USER_EMAIL: ${{ secrets.JIRA_USER_EMAIL }}
         JIRA_API_TOKEN: ${{ secrets.JIRA_API_TOKEN }}
     - name: Jira Create issue
       id: create_jira_issue
-      uses: atlassian/gajira-create@v3.0.1
+      uses: atlassian/gajira-create@59e177c4f6451399df5b4911c2211104f171e669 # v3.0.1
       with:
         project: GEOPY
         issuetype: Story
@@ -28,7 +28,7 @@ jobs:
         # Additional fields in JSON format
         fields: '{"components": [{"name": "geoapps"}]}'
     - name: Post JIRA link
-      uses: peter-evans/create-or-update-comment@v4
+      uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4.0.0
       with:
         # The number of the issue or pull request in which to create a comment.
         issue-number: ${{ github.event.issue.number }}

--- a/.github/workflows/pr_jira_actions.yml
+++ b/.github/workflows/pr_jira_actions.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   call-workflow-pr_jira_actions:
-    uses: MiraGeoscience/CI-tools/.github/workflows/reusable-jira-pr_actions.yml@v3
+    uses: MiraGeoscience/CI-tools/.github/workflows/reusable-jira-pr_actions.yml@7241532854727d993872b67fc761139b8438615b # v3.12.0
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/pytest-unix-os.yml
+++ b/.github/workflows/pytest-unix-os.yml
@@ -40,11 +40,11 @@ jobs:
       PIP_NO_DEPS: 1 # all dependencies are installed from conda
       CONDA_LOCK_ENV_FILE: environments/py-${{ matrix.python_ver }}-${{ startsWith(matrix.os, 'macos') && 'osx' || 'linux' }}-64-dev.conda.lock.yml
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           lfs: true
       - name: Setup conda env
-        uses: mamba-org/setup-micromamba@v1
+        uses: mamba-org/setup-micromamba@4b9113af4fba0e9e1124b252dd6497a419e7396d # v1.11.0
         with:
           environment-file: ${{ env.CONDA_LOCK_ENV_FILE }}
           environment-name: test_env

--- a/.github/workflows/pytest-windows.yml
+++ b/.github/workflows/pytest-windows.yml
@@ -39,11 +39,11 @@ jobs:
       PIP_NO_DEPS: 1 # all dependencies are installed from conda
       CONDA_LOCK_ENV_FILE: environments/py-${{ matrix.python_ver }}-win-64-dev.conda.lock.yml
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           lfs: true
       - name: Setup conda env
-        uses: mamba-org/setup-micromamba@v1
+        uses: mamba-org/setup-micromamba@4b9113af4fba0e9e1124b252dd6497a419e7396d # v1.11.0
         with:
           environment-file: ${{ env.CONDA_LOCK_ENV_FILE }}
           environment-name: test_env
@@ -53,7 +53,7 @@ jobs:
         run: pytest --cov --cov-report=xml
       - name: Codecov
         if: ${{ success() && matrix.python_ver == '3.10' }}
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
         with:
           name: GitHub
           fail_ci_if_error: true

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -38,9 +38,9 @@ jobs:
       PIP_NO_DEPS: 1 # all dependencies are installed from conda
       CONDA_LOCK_ENV_FILE: environments/py-3.10-linux-64-dev.conda.lock.yml
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
       - name: Setup conda env
-        uses: mamba-org/setup-micromamba@v1
+        uses: mamba-org/setup-micromamba@4b9113af4fba0e9e1124b252dd6497a419e7396d # v1.11.0
         with:
           environment-file: ${{ env.CONDA_LOCK_ENV_FILE }}
           environment-name: linter_env

--- a/.github/workflows/wip-status.yml
+++ b/.github/workflows/wip-status.yml
@@ -1,0 +1,12 @@
+name: WIP status
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review, edited]
+
+jobs:
+  call-workflow-wip-status:
+    uses: MiraGeoscience/CI-tools/.github/workflows/reusable-wip-status.yml@7241532854727d993872b67fc761139b8438615b # v3.12.0
+    permissions:
+      contents: read
+      statuses: write


### PR DESCRIPTION
**DEVOPS-1133 - pin all GitHub actions and reusable workflows to hash**
Expands moving GitHub Actions tags to the full semver tag pointing at the same commit, then pins every `uses:` to a commit hash with a dependabot-readable version comment.

Tags expanded in this repo:

- `atlassian/gajira-login@v3.0.1 -> @v3.0.1`
- `atlassian/gajira-create@v3.0.1 -> @v3.0.1`
- `peter-evans/create-or-update-comment@v4 -> @v4.0.0`
- `MiraGeoscience/CI-tools/.github/workflows/reusable-jira-pr_actions.yml@v3 -> @v3.12.0`
- `actions/checkout@v4 -> @v4.4.0`
- `mamba-org/setup-micromamba@v1 -> @v1.11.0`
- `codecov/codecov-action@v4 -> @v4.6.0`

Workflows added:

- `.github/workflows/dependabot-auto-merge.yml`
- `.github/workflows/wip-status.yml`

All `MiraGeoscience/CI-tools` reusable workflows are pinned to `7241532854727d993872b67fc761139b8438615b` (**v3.12.0**).
